### PR TITLE
Add MapEntry to default-write-handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml
 *.asc
 resources/public/js*
 resources/wasm-test/target/*
+.clj-kondo

--- a/deps.edn
+++ b/deps.edn
@@ -10,4 +10,4 @@
                   :extra-deps {org.clojure/tools.reader {:mvn/version "1.3.0"}}}
            :wasm-test {:extra-paths ["src/test_common" "src/wasm_test"]
                        :extra-deps {org.clojure/core.async {:mvn/version "0.4.474"}
-                                    cargo-cljs {:mvn/version "0.1.0"}}}}}
+                                    cargo-cljs/cargo-cljs {:mvn/version "0.1.0"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                    (let [deps (get-in raw-deps [:aliases alias-key :extra-deps])]
                      [alias-key {:dependencies (deps->vec deps)
                                  :cljsbuild {:builds builds}}])))]
-  (defproject fress "0.3.1"
+  (defproject fress "0.3.2"
     :description "Fressian for clojure(script) and WASM"
     :url "https://github.com/pkpkpk/fress"
     :repositories [["clojars" {:sign-releases false}]]

--- a/src/main/cljs/fress/writer.cljs
+++ b/src/main/cljs/fress/writer.cljs
@@ -467,6 +467,7 @@
    cljs.core/PersistentHashMap writeMap
    cljs.core/PersistentArrayMap writeMap
    cljs.core/ObjMap writeMap
+   cljs.core/MapEntry writeList
    cljs.core/PersistentVector writeList
    cljs.core/EmptyList writeList
    cljs.core/List writeList


### PR DESCRIPTION
Adds MapEntry to `default-write-handlers`. Type added to Clojurescript since v1.9.542 - https://cljs.github.io/api/cljs.core/MapEntry. 

This change is currently sufficient for downstream users of the library on later versions of Clojurescript.